### PR TITLE
create_quality_gate updated to return gate id

### DIFF
--- a/sonarqube/qualitygates.py
+++ b/sonarqube/qualitygates.py
@@ -40,10 +40,11 @@ class SonarQubeQualityGates:
         Create a Quality Gate.
 
         :param gate_name: The name of the quality gate to create
-        :return:
+        :return: Returns id and name of quality gate
         """
         params = {'name': gate_name}
-        self.sonarqube.make_call('post', API_QUALITYGATES_CREATE_ENDPOINT, **params)
+        res = self.sonarqube.make_call('post', API_QUALITYGATES_CREATE_ENDPOINT, **params)
+        return res
 
     def delete_quality_gate(self, gate_id):
         """


### PR DESCRIPTION
It will be good if we can get quality gate id after creating it.
Many cases arrive where we have to use it in development.
Sonarquube guys haven't updated or may be missed to mention the response in their docs