### PR TITLE
Add API to retrieve users and groups for a given template

### DIFF
--- a/docs/examples/permissions.rst
+++ b/docs/examples/permissions.rst
@@ -89,6 +89,14 @@ List permission templates.::
 
     templates = sonar.permissions.search_templates()
 
+Retrieve users for specified template id.::
+
+    templateUsers = sonar.permissions.get_template_users(templateId="AXQqe0yfjOKlq86mQn4t");
+
+Retrieve groups for specified template id.::
+
+    templateGroups = sonar.permissions.get_template_users(templateId="AXQqe0yfjOKlq86mQn4t");
+
 Set a permission template as default.::
 
     sonar.permissions.set_default_template(templateName="test-template")

--- a/sonarqube/community/permissions.py
+++ b/sonarqube/community/permissions.py
@@ -20,8 +20,10 @@ from sonarqube.utils.config import (
     API_PERMISSIONS_SEARCH_TEMPLATES_ENDPOINT,
     API_PERMISSIONS_SET_DEFAULT_TEMPLATE_ENDPOINT,
     API_PERMISSIONS_UPDATE_TEMPLATE_ENDPOINT,
+    API_PERMISSIONS_GET_TEMPLATE_USERS,
+    API_PERMISSIONS_GET_TEMPLATE_GROUPS,
 )
-from sonarqube.utils.common import GET, POST
+from sonarqube.utils.common import GET, POST, PAGE_GET
 
 
 class SonarQubePermissions(RestClient):
@@ -255,6 +257,24 @@ class SonarQubePermissions(RestClient):
 
         :param q: Limit search to permission template names that contain the supplied string.
         :return: defaultTemplates, permissionTemplates, permissions
+        """
+
+    @PAGE_GET(API_PERMISSIONS_GET_TEMPLATE_USERS, item="users")
+    def get_template_users(self, templateId):
+        """
+        List of users and their permissions for the specified template.
+
+        :param templateId: Id of permission template
+        return: users
+        """
+
+    @PAGE_GET(API_PERMISSIONS_GET_TEMPLATE_GROUPS, item="groups")
+    def get_template_groups(self, templateId):
+        """
+        List of groups and their permissions for the specified template.
+
+        :param templateId: Id of permission template
+        return: groups
         """
 
     @POST(API_PERMISSIONS_SET_DEFAULT_TEMPLATE_ENDPOINT)

--- a/sonarqube/community/projects.py
+++ b/sonarqube/community/projects.py
@@ -37,7 +37,6 @@ class SonarQubeProjects(RestClient):
     def search_projects(
         self,
         analyzedBefore=None,
-        onProvisionedOnly="false",
         projects=None,
         q=None,
         qualifiers="TRK",

--- a/sonarqube/utils/config.py
+++ b/sonarqube/utils/config.py
@@ -61,6 +61,8 @@ API_PERMISSIONS_REMOVE_USER_FROM_TEMPLATE_ENDPOINT = (
 API_PERMISSIONS_SEARCH_TEMPLATES_ENDPOINT = "/api/permissions/search_templates"
 API_PERMISSIONS_SET_DEFAULT_TEMPLATE_ENDPOINT = "/api/permissions/set_default_template"
 API_PERMISSIONS_UPDATE_TEMPLATE_ENDPOINT = "/api/permissions/update_template"
+API_PERMISSIONS_GET_TEMPLATE_USERS = "/api/permissions/template_users"
+API_PERMISSIONS_GET_TEMPLATE_GROUPS = "/api/permissions/template_groups"
 
 API_CE_ACTIVITY_ENDPOINT = "/api/ce/activity"
 API_CE_ACTIVITY_STATUS_ENDPOINT = "/api/ce/activity_status"


### PR DESCRIPTION
There is a change in here that involved removing a default parameter on the `search_projects` api call. For some reason, we can only get that function working with that removed. Thoughts?