### PR TITLE
fix links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Documentation
 =============
 
 The full documentation for API is available on `readthedocs
-<https://python-sonarqube-api.readthedocs.io/en/1.2.4/>`_.
+<https://python-sonarqube-api.readthedocs.io/en/latest/>`_.
 
 
 Compatibility
@@ -96,5 +96,5 @@ API example
 -----------
 
 The example documentation for SonarQubeClient APIs is available on `API examples
-<https://python-sonarqube-api.readthedocs.io/en/1.2.4/examples.html>`_.
+<https://python-sonarqube-api.readthedocs.io/en/latest/examples.html>`_.
 


### PR DESCRIPTION
The Links pointing to the documentation included `1.2.4` which is apparently not working. I would suggest to use the `latest` path tag from readthedocs.