### PR TITLE
Replaced gateId by gateName as per version 8.4. as it is deprecated.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Compatibility
 =============
 
 * This package is compatible Python versions 2.7, 3.3+.
-* Tested with SonarQube Community Edition 7.9.x LTS and SonarCloud Server.
+* Tested with SonarQube Community Edition 8.9.x LTS and SonarCloud Server.
 
 Donate
 ======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = '2020, Jialiang Shi'
 author = 'Jialiang Shi'
 
 # The full version, including alpha/beta/rc tags
-release = '1.3.4'
+release = '1.3.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name='python-sonarqube-api',
 
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.3.4',
+    version='1.3.5',
 
     description='Python wrapper for the SonarQube and SonarCloud API.',
     long_description=long_description,

--- a/sonarqube/community/qualitygates.py
+++ b/sonarqube/community/qualitygates.py
@@ -218,13 +218,13 @@ class SonarQubeQualityGates(RestClient):
         """
 
     @POST(API_QUALITYGATES_SELECT_ENDPOINT)
-    def select_quality_gate_for_project(self, projectKey, gateId, organization=None):
+    def select_quality_gate_for_project(self, projectKey, gateName, organization=None):
         """
         SINCE 4.3
         Associate a project to a quality gate.
 
         :param projectKey: Project key
-        :param gateId: Quality gate id
+        :param gateName: Quality gate name (since version 8.4). Refer https://sonarqube.inria.fr/sonarqube/web_api/api/qualitygates
         :param organization: Organization key. If no organization is provided, the default organization is used.
         :return:
         """


### PR DESCRIPTION
Refer https://sonarqube.inria.fr/sonarqube/web_api/api/qualitygates

`POST api/qualitygates/select` do not support `gateId` anymore and it has been deprecated. The new parameter is `gateName`.

Tested the change with SonarQube CE version 8.9.9. There are no more integers in the quality gates like 100, 827, etc it is alpha-numeric now and treated as a String.